### PR TITLE
Fixes disconnected vnd.docker.raw-streams output

### DIFF
--- a/src/Docker/Http/Stream/Filter/Event.php
+++ b/src/Docker/Http/Stream/Filter/Event.php
@@ -69,12 +69,12 @@ class Event extends \php_user_filter implements HasEmitterInterface
                 return PSFS_FEED_ME;
             }
 
-            $data         = substr($data, 8, $decoded['size']);
+            $output         = substr($data, 8, $decoded['size']);
             $type         = $decoded['stream_type'];
             $this->buffer = substr($data, 8 + $decoded['size']);
 
-            if (!empty($data)) {
-                $this->getEmitter()->emit('response.output', new OutputEvent($data, $type));
+            if (!empty($output)) {
+                $this->getEmitter()->emit('response.output', new OutputEvent($output, $type));
             }
 
             return PSFS_PASS_ON;

--- a/src/Docker/Http/Stream/Filter/Event.php
+++ b/src/Docker/Http/Stream/Filter/Event.php
@@ -44,6 +44,19 @@ class Event extends \php_user_filter implements HasEmitterInterface
         $bucket = stream_bucket_make_writeable($in);
 
         if (null == $bucket) {
+            $remainder = $this->buffer;
+            while (strlen($remainder) > 0) {
+                $header  = substr($remainder, 0, 8);
+                $decoded = unpack('C1stream_type/C3/N1size', $header);
+                $output = substr($remainder, 8, $decoded['size']);
+                $type = $decoded['stream_type'];
+                $remainder = substr($remainder, 8 + $decoded['size']);
+
+                if (!empty($output)) {
+                    $this->getEmitter()->emit('response.output', new OutputEvent($output, $type));
+                }
+            }
+
             return PSFS_PASS_ON;
         }
 

--- a/src/Docker/Http/Stream/Filter/Event.php
+++ b/src/Docker/Http/Stream/Filter/Event.php
@@ -45,6 +45,7 @@ class Event extends \php_user_filter implements HasEmitterInterface
 
         if (null == $bucket) {
             $remainder = $this->buffer;
+            $this->buffer = '';
             while (strlen($remainder) > 0) {
                 $header  = substr($remainder, 0, 8);
                 $decoded = unpack('C1stream_type/C3/N1size', $header);


### PR DESCRIPTION
Oftentimes our executions would seem to bail out. They would continue to run, but the stream would be severed and we could not see the output from the stream. Traced it to the data variable being overwritten, and thus the buffer not properly being updated for the next bucket.  There may still be an issue with the very last bucket still containing more than one decoded control code series, but this gets us most of the way there.
